### PR TITLE
fix: update CI badge links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Leftovers Tracker
 
-[![CI](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-client.yml/badge.svg)](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci.yml)
+[![CI](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci.yml)
 [![codecov-client](https://codecov.io/gh/nickperkins/leftovers-tracker/branch/main/graph/badge.svg?flag=client)](https://codecov.io/gh/nickperkins/leftovers-tracker)
 [![codecov-server](https://codecov.io/gh/nickperkins/leftovers-tracker/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/nickperkins/leftovers-tracker)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Leftovers Tracker
 
-[![Client CI](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-client.yml/badge.svg)](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-client.yml)
+[![CI](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-client.yml/badge.svg)](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci.yml)
 [![codecov-client](https://codecov.io/gh/nickperkins/leftovers-tracker/branch/main/graph/badge.svg?flag=client)](https://codecov.io/gh/nickperkins/leftovers-tracker)
-[![Server CI](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-server.yml/badge.svg)](https://github.com/nickperkins/leftovers-tracker/actions/workflows/ci-server.yml)
 [![codecov-server](https://codecov.io/gh/nickperkins/leftovers-tracker/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/nickperkins/leftovers-tracker)
 
 A web application to track leftover meals in your freezer or fridge using GraphQL and React.


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change simplifies the CI badge by consolidating it into a single "CI" badge that links to a unified workflow.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L5): Replaced separate "Client CI" and "Server CI" badges with a single "CI" badge that links to the unified CI workflow.